### PR TITLE
fix: refresh token 조건 수정, 예외처리 정리

### DIFF
--- a/src/main/java/com/sparta/communityback/security/AuthExceptionFilter.java
+++ b/src/main/java/com/sparta/communityback/security/AuthExceptionFilter.java
@@ -29,18 +29,13 @@ public class AuthExceptionFilter extends OncePerRequestFilter {
             log.error(e.getMessage());
             response.setStatus(HttpStatus.BAD_REQUEST.value());
             response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-            response.setCharacterEncoding("UTF-8");
+            response.setContentType("application/json;charset=UTF-8");
             // response body에 넣을 json 형태의 값
             StatusResponseDto statusCodesResponseDto = new StatusResponseDto(
                     HttpStatus.BAD_REQUEST.value(),
-                    e.getMessage());
+                    "로그인이 필요합니다.");
 
-            String json = new ObjectMapper().writeValueAsString(statusCodesResponseDto);
-
-            response.getWriter().write(json);
-//            response.setStatus(HttpStatus.BAD_REQUEST.value());
-//            response.setContentType("application/json;charset=UTF-8");
-//            new ObjectMapper().writeValue(response.getOutputStream(), statusCodesResponseDto);
+            new ObjectMapper().writeValue(response.getOutputStream(), statusCodesResponseDto);
         }
     }
 }

--- a/src/main/java/com/sparta/communityback/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sparta/communityback/security/JwtAuthenticationFilter.java
@@ -52,28 +52,27 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 
     protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authResult) throws IOException {
         log.info("successfulAuthentication");
-        if(request.getHeader("AccessToken") == null && request.getHeader("RefreshToken") == null) {
-            String username = ((UserDetailsImpl) authResult.getPrincipal()).getUsername();
-            UserRoleEnum role = ((UserDetailsImpl) authResult.getPrincipal()).getUser().getRole();
-            Long userId = ((UserDetailsImpl) authResult.getPrincipal()).getUser().getId();
+        String username = ((UserDetailsImpl) authResult.getPrincipal()).getUsername();
+        UserRoleEnum role = ((UserDetailsImpl) authResult.getPrincipal()).getUser().getRole();
+        Long userId = ((UserDetailsImpl) authResult.getPrincipal()).getUser().getUserId();
 
+        String accessToken = jwtUtil.createAccessToken(username, role);
+        response.addHeader(JwtUtil.ACCESS_TOKEN, accessToken);
 
-            String accessToken = jwtUtil.createAccessToken(username, role);
-            response.addHeader(JwtUtil.ACCESS_TOKEN, accessToken);
-
-            // redis userid값으로 조회후 동일한 값이 존재한다면 중복로그인은 불가능하다로 에러처리
-            String refreshToken = jwtUtil.createRefreshToken(username);
+        // redis userid값으로 조회후 동일한 값이 존재한다면 중복로그인은 불가능하다로 에러처리
+        String refreshToken = redisService.getRefreshToken(userId);
+        if (refreshToken != null) {
             response.addHeader(JwtUtil.REFRESH_TOKEN, refreshToken);
+        } else {
+            String newRefreshToken = jwtUtil.createRefreshToken(username);
+            response.addHeader(JwtUtil.REFRESH_TOKEN, newRefreshToken);
             // redis에 저장
-            redisService.setRefreshToken(new RefreshToken(refreshToken, userId));
+            redisService.setRefreshToken(new RefreshToken(newRefreshToken, userId));
+        }
 
-            response.setStatus(200);
-            response.setContentType("application/json;charset=UTF-8");
-            new ObjectMapper().writeValue(response.getOutputStream(), new ResultResponseDto("로그인 성공"));
-        }
-        else{
-            new ObjectMapper().writeValue(response.getOutputStream(), new ResultResponseDto("로그인 실패"));
-        }
+        response.setStatus(200);
+        response.setContentType("application/json;charset=UTF-8");
+        new ObjectMapper().writeValue(response.getOutputStream(), new ResultResponseDto("로그인 성공"));
 //             // Jwt 쿠키 저장
 //             jwtUtil.addJwtToCookie(token, response);
 

--- a/src/main/java/com/sparta/communityback/security/JwtAuthorizationFilter.java
+++ b/src/main/java/com/sparta/communityback/security/JwtAuthorizationFilter.java
@@ -1,6 +1,7 @@
 package com.sparta.communityback.security;
 
 import com.sparta.communityback.jwt.JwtUtil;
+import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -27,11 +28,13 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain filterChain) throws ServletException, IOException {
 //         String tokenValue = jwtUtil.getTokenFromRequest(req);
         String tokenValue = jwtUtil.getJwtFromHeader(req);
-        if (StringUtils.hasText(tokenValue)) {
+//        if (StringUtils.hasText(tokenValue)) {
             if (!jwtUtil.validateToken(tokenValue, req, res)) {
                 log.error("Token Error: 토큰 재발급이 되었다면 에러가 아닙니다.");
-                return;
-              
+                tokenValue = res.getHeader(jwtUtil.ACCESS_TOKEN).substring(7);
+
+                System.out.println("tokenValue = " + tokenValue);
+            }
             Claims info = jwtUtil.getUserInfoFromToken(tokenValue);
 
             try {
@@ -41,20 +44,20 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
                 throw new AuthorizationServiceException(e.getMessage());
 
             }
-        }
+//        }
 
         filterChain.doFilter(req, res);
     }
     // 인증 처리
-//    public void setAuthentication(String username) {
-//        Authentication authentication = createAuthentication(username);
-//        SecurityContextHolder.getContext().setAuthentication(authentication);
-//        log.info("인증처리: {}", (SecurityContextHolder.getContext().getAuthentication()));
-//    }
-//
-//    // 인증 객체 생성
-//    private Authentication createAuthentication(String username) {
-//        UserDetailsImpl userDetails = (UserDetailsImpl) userDetailsService.loadUserByUsername(username);
-//        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
-//    }
+    public void setAuthentication(String username) {
+        Authentication authentication = createAuthentication(username);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        log.info("인증처리: {}", (SecurityContextHolder.getContext().getAuthentication()));
+    }
+
+    // 인증 객체 생성
+    private Authentication createAuthentication(String username) {
+        UserDetailsImpl userDetails = (UserDetailsImpl) userDetailsService.loadUserByUsername(username);
+        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+    }
 }

--- a/src/main/java/com/sparta/communityback/service/RedisService.java
+++ b/src/main/java/com/sparta/communityback/service/RedisService.java
@@ -7,6 +7,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Service;
 
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 
@@ -26,4 +27,21 @@ public class RedisService {
         ValueOperations<String, String> values = redisTemplate.opsForValue();
         return values.get(refreshToken);
     }
+
+    public String getRefreshToken(Long userId) {
+        ValueOperations<String, String> values = redisTemplate.opsForValue();
+
+// Redis에서 key를 찾기 위해 모든 키를 순회합니다.
+        Set<String> keys = redisTemplate.keys("*");
+        for (String key : keys) {
+            String value = values.get(key);
+            if (value != null && Long.parseLong(value) == userId) {
+                return key; // userId와 일치하는 value를 가진 key를 반환합니다.
+            }
+        }
+
+// 일치하는 userId가 없을 경우 null을 반환합니다.
+        return null;
+    }
+
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,4 +11,5 @@ spring.data.redis.database=0
 spring.data.redis.host=localhost
 spring.data.redis.port=6379
 
-jwt.secret.key=7Iqk7YyM66W07YOA7L2U65Sp7YG065+9U3ByaW5n6rCV7J2Y7Yqc7YSw7LWc7JuQ67mI7J6F64uI64ukLg==
+# application-secret.properties
+spring.profiles.include=secret


### PR DESCRIPTION
refresh 토큰을 가지고 있지만 access token이 만료 되었거나, access token이 없는 경우 새로 access token을 발급해서 처리,
기존에 refresh 토큰을 가지고 있는 사용자가 다른 브라우저로 접속했을경우 새로운 refresh 토큰을 발급하는 것이 아닌 기존의 refresh 토큰을 발급
이외에 예외처리 약간